### PR TITLE
move chirps earlier

### DIFF
--- a/.github/workflows/run_update_chirps_gefs.yml
+++ b/.github/workflows/run_update_chirps_gefs.yml
@@ -2,7 +2,7 @@ name: Download recent CHIRPS-GEFS
 
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '50 8 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
moving CHIRPS pipeline 10 minutes earlier to ensure that the data is there in time for the NHC forecast coming in