### PR TITLE
Fix framework doc links

### DIFF
--- a/src/email/templates/action.html
+++ b/src/email/templates/action.html
@@ -7,7 +7,7 @@
     Le seuil du déclencheur d'action du cadre d'action anticipatoire pour les ouragans en Haïti a été atteint, conformément à la prévision émise à {{ pub_time }}, {{ pub_date }} (heure locale d'Haïti) par le National Hurricane Center de NOAA, l'opérateur du Centre météorologique régional spécialisé Miami, et à la prévision des précipitations CHIRPS-GEFS du CHC de UC Santa Barbara. Le <a href="https://www.meteo-haiti.gouv.ht/cyclone.php">Communiqué d'activité cyclonique</a> publié par l'Unité HydroMétéorologique d'Haïti confirme les prévisions de NOAA.
   </p>
   <p>
-    Toutes les activités conformes au <a href="https://reliefweb.int/report/fiji/fiji-tropical-cyclones-2023-anticipatory-action-framework">document du cadre</a> doivent maintenant commencer. OCHA peut convoquer une réunion des partenaires participants.
+    Toutes les activités conformes au <a href="https://www.unocha.org/publications/report/haiti/cadre-daction-anticipatoire-pilote-en-haiti-tempetesouragans">document du cadre</a> doivent maintenant commencer. OCHA peut convoquer une réunion des partenaires participants.
   </p>
   <p>Meilleures salutations et bonne chance,</p>
   <p>Centre de données humanitaires OCHA</p>

--- a/src/email/templates/base.html
+++ b/src/email/templates/base.html
@@ -89,7 +89,7 @@ font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif
 <h1>Haïti : suivi des ouragans</h1>
 <div style="font-size:10px;padding: 6px 10px 6px 10px;background-color:#CCCCCC;color:#FFFFFF">
   <p style="margin:0;">
-    Ceci est un message automatisé produit par le Centre de données humanitaires d'OCHA pour le <a href="https://reliefweb.int/report/fiji/fiji-tropical-cyclones-2023-anticipatory-action-framework">cadre d'action anticipatoire des ouragans en Haïti</a>.
+    Ceci est un message automatisé produit par le Centre de données humanitaires d'OCHA pour le <a href="https://www.unocha.org/publications/report/haiti/cadre-daction-anticipatoire-pilote-en-haiti-tempetesouragans">cadre d'action anticipatoire des ouragans en Haïti</a>.
   </p>
 </div>
 <div id="anticipatory-action-typhoon-trigger-status" class="section level2">

--- a/src/email/templates/observational.html
+++ b/src/email/templates/observational.html
@@ -7,7 +7,7 @@
     Le seuil du déclencheur observationnel du cadre d'action anticipatoire pour les ouragans en Haïti a été atteint, conformément aux données observationnels émises jusqu'à {{ pub_time }}, {{ pub_date }} (heure locale d'Haïti) par le National Hurricane Center de NOAA, l'opérateur du Centre météorologique régional spécialisé Miami, et aux données observationnels de précipitations IMERG de NASA. Le <a href="https://www.meteo-haiti.gouv.ht/cyclone.php">Communiqué d'activité cyclonique</a> publié par l'Unité HydroMétéorologique d'Haïti confirme les observations de NOAA.
   </p>
   <p>
-    Toutes les activités conformes au <a href="https://reliefweb.int/report/fiji/fiji-tropical-cyclones-2023-anticipatory-action-framework">document du cadre</a> doivent maintenant commencer. OCHA peut convoquer une réunion des partenaires participants.
+    Toutes les activités conformes au <a href="https://www.unocha.org/publications/report/haiti/cadre-daction-anticipatoire-pilote-en-haiti-tempetesouragans">document du cadre</a> doivent maintenant commencer. OCHA peut convoquer une réunion des partenaires participants.
   </p>
   <p>Meilleures salutations et bonne chance,</p>
   <p>Centre de données humanitaires OCHA</p>

--- a/src/email/templates/readiness.html
+++ b/src/email/templates/readiness.html
@@ -7,7 +7,7 @@
     Le seuil du déclencheur de mobilisation du cadre d'action anticipatoire pour les ouragans en Haïti a été atteint, conformément à la prévision émise à {{ pub_time }}, {{ pub_date }} (heure locale d'Haïti) par le National Hurricane Center de NOAA, l'opérateur du Centre météorologique régional spécialisé Miami, et à la prévision des précipitations CHIRPS-GEFS du CHC de UC Santa Barbara. Le <a href="https://www.meteo-haiti.gouv.ht/cyclone.php">Communiqué d'activité cyclonique</a> publié par l'Unité HydroMétéorologique d'Haïti confirme les prévisions de NOAA.
   </p>
   <p>
-    Les activités de mobilisation conformes au <a href="https://reliefweb.int/report/fiji/fiji-tropical-cyclones-2023-anticipatory-action-framework">document du cadre</a> doivent maintenant commencer. Le financement du CERF destiné aux agences des Nations unies est en train d'être débloqué de manière automatique. OCHA peut convoquer une réunion des partenaires participants.
+    Les activités de mobilisation conformes au <a href="https://www.unocha.org/publications/report/haiti/cadre-daction-anticipatoire-pilote-en-haiti-tempetesouragans">document du cadre</a> doivent maintenant commencer. Le financement du CERF destiné aux agences des Nations unies est en train d'être débloqué de manière automatique. OCHA peut convoquer une réunion des partenaires participants.
   </p>
   <p>Meilleures salutations et bonne chance,</p>
   <p>Centre de données humanitaires OCHA</p>


### PR DESCRIPTION
Fixing framework document links in the emails (used to be Fiji framework doc instead)