### PR TITLE
Move plot legend

### DIFF
--- a/exploration/plot_legend_check.md
+++ b/exploration/plot_legend_check.md
@@ -1,0 +1,38 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.1
+  kernelspec:
+    display_name: ds-aa-hti-hurricanes
+    language: python
+    name: ds-aa-hti-hurricanes
+---
+
+# Map plot legend move
+
+```python
+%load_ext jupyter_black
+%load_ext autoreload
+%autoreload 2
+```
+
+```python
+from src.email.plotting import create_map_plot
+```
+
+```python
+monitor_id = "al132025_fcast_2025-10-28T15:00:00"
+```
+
+```python
+create_map_plot(monitor_id, "fcast")
+```
+
+```python
+
+```

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -502,17 +502,18 @@ def create_map_plot(monitor_id: str, fcast_obsv: Literal["fcast", "obsv"]):
                 source=f"data:image/png;base64,{encoded_legend}",
                 xref="paper",
                 yref="paper",
-                x=0.01,
+                x=0.99,
                 y=0.01,
                 sizex=0.3,
                 sizey=0.3 / aspect,
-                xanchor="left",
+                xanchor="right",
                 yanchor="bottom",
                 opacity=0.7,
             )
         ],
     )
-
+    # uncomment to return fig for testing
+    # return fig
     buffer = io.BytesIO()
     # scale corresponds to 150 dpi
     fig.write_image(buffer, format="png", scale=2.08)


### PR DESCRIPTION
Moving legend of map plot to bottom right to not obscure the track forecast. Not ideal fix since it's just hard-coded but it works for now.